### PR TITLE
Added button state output to AT SR reporting of live values

### DIFF
--- a/FabiWare/FabiWare.ino
+++ b/FabiWare/FabiWare.ino
@@ -94,6 +94,9 @@ uint8_t neoPix_b_old = 0;
 int inByte = 0;
 uint16_t pressure = 0;
 uint8_t reportRawValues = 0;
+/** current button states for reporting raw values (AT SR)
+ * @note If NUMBER_OF_BUTTONS is more than 16, change type to uint32_t! */
+uint16_t buttonStates = 0;
 
 uint8_t cnt = 0, cnt2 = 0;
 uint8_t buzzerPIN = 0;
@@ -292,7 +295,13 @@ void loop() {
 
     if (reportRawValues)   {
       if (valueReportCount++ > 10) {      // report raw values !
-        Serial.print("VALUES:"); Serial.print(pressure); Serial.println(",");
+        Serial.print("VALUES:"); Serial.print(pressure); Serial.print(",");
+        for(uint8_t i = 0; i<NUMBER_OF_BUTTONS; i++)
+        {
+		  if(buttonStates & (1<<i)) Serial.print("1");
+		  else Serial.print("0");
+	    }
+        Serial.println("");
         valueReportCount = 0;
       }
     }
@@ -344,11 +353,13 @@ void loop() {
 
 void handlePress (int buttonIndex)   // a button was pressed
 {
+  buttonStates |= (1<<buttonIndex); //save for reporting
   performCommand(buttons[buttonIndex].mode, buttons[buttonIndex].value, getKeystring(buttonIndex), 1);
 }
 
 void handleRelease (int buttonIndex)    // a button was released
 {
+  buttonStates &= ~(1<<buttonIndex); //save for reporting
   switch (buttons[buttonIndex].mode) {
     case CMD_PL: leftMouseButton = 0; break;
     case CMD_PR: rightMouseButton = 0; break;

--- a/FabiWare/fabi.h
+++ b/FabiWare/fabi.h
@@ -37,7 +37,7 @@
   #define EEPROM_SIZE        4096     // maximum size of EEPROM storage for Teensy2.0++
 #endif
 
-#define NUMBER_OF_BUTTONS  11         // number of connected or virtual switches
+#define NUMBER_OF_BUTTONS  11         // number of connected or virtual switches, note: if more than 16, change buttonState type to uint32_t!
 #define NUMBER_OF_PHYSICAL_BUTTONS 9  // number of connected switches
 #define NUMBER_OF_LEDS     3          // number of connected leds
 


### PR DESCRIPTION
If reporting of live values is started (`AT SR`),
an additional field is transmitted, which represents all button states, e.g.:
```
VALUES:520,00000000000
VALUES:520,10000000000
VALUES:520,01000000000
VALUES:520,00000000000
```
Position is determined by the number of the button, starting with button 1.
Sip/Puff are defined as 9 & 10 (`PUFF_BUTTON` and `SIP_BUTTON`).