### PR TITLE
Added "AT UG", fixed Serial1 garbage if no addon is attached

### DIFF
--- a/FabiWare/FabiWare.ino
+++ b/FabiWare/FabiWare.ino
@@ -46,6 +46,8 @@ uint8_t PCBversion = 0;        // 1 == PCB version
 uint32_t updateTimestamp = 0;
 uint8_t actSlot = 0;           // the index of the currently active configuration slot
                                // note: this is changes in eeprom.cpp when a new slot is loaded
+uint8_t addonUpgrade = 0;      //is != 0, if we are upgrading the addon module.
+uint8_t readstate_f=0;         //needed to track the return value status during addon upgrade mode
 int waitTime = DEFAULT_WAIT_TIME;
 
 void UpdateLeds();
@@ -70,6 +72,7 @@ void setup() {
   
   //check if PCB or old (floating wire) FABI is used (checkPin to ground = PCB):
   pinMode(PCB_checkPin, INPUT_PULLUP);
+  pinMode(0,INPUT_PULLUP);
 
   if (!digitalRead(PCB_checkPin)) {            //PCB Version detected
     PCBversion = 1;
@@ -126,6 +129,57 @@ void setup() {
    main program loop, processes serial commands and button actions. 
 */
 void loop() {
+  //check if we should go into addon upgrade mode
+	if(addonUpgrade != 0)
+	{
+		//update start
+		if(addonUpgrade == 2)
+		{
+			Serial1.end();
+			pinMode(0,INPUT);
+			Serial1.begin(500000); //switch to higher speed...
+			Serial.flush();
+			Serial1.flush();
+      //remove everything from buffers...
+			while(Serial.available()) Serial.read();
+			while(Serial1.available()) Serial1.read();
+			addonUpgrade = 1;
+			return;
+		}
+
+		if(addonUpgrade == 1)
+		{
+			while(Serial.available()) Serial1.write(Serial.read());
+			while(Serial1.available()) {
+				int inByte = Serial1.read();
+				Serial.write(inByte);
+				switch (readstate_f) {
+				  case 0:
+						  if (inByte=='$') readstate_f++;
+					   break;
+				  case 1:
+						  if (inByte=='F') readstate_f++; else readstate_f=0;
+					  break;
+				  case 2:
+						  if (inByte=='I') readstate_f++; else readstate_f=0;
+					  break;
+				  case 3:
+						  if (inByte=='N') {
+							addonUpgrade = 0;
+							readstate_f=0;
+							delay(50);
+							Serial1.begin(9600); //switch to lower speed...
+							Serial.flush();
+							Serial1.flush();
+						  } else readstate_f=0;
+					  break;
+				  default: 
+					readstate_f=0;
+				}
+			}
+		return;
+		}
+	}
 
   while (Serial.available() > 0) {
     // get incoming bytes for Serial

--- a/FabiWare/bluetooth.cpp
+++ b/FabiWare/bluetooth.cpp
@@ -310,7 +310,7 @@ void initBluetooth()
 
   ///@todo send identifier to BT module & check response. With BT addon this is much faster and reliable
   bt_esp32addon = EZKEY;
-  Serial_AUX.println("$ID");
+  //Serial_AUX.println("$ID");
   //set BT name to FABI
   Serial_AUX.println("$NAME FABI");
 }

--- a/FabiWare/commands.cpp
+++ b/FabiWare/commands.cpp
@@ -37,7 +37,7 @@ const struct atCommandType atCommands[] PROGMEM = {
     {"TS"  , PARTYPE_UINT },  {"TP"  , PARTYPE_UINT }, {"MA"  , PARTYPE_STRING},{"WA"  , PARTYPE_UINT  },
     {"TT"  , PARTYPE_UINT },  {"AP"  , PARTYPE_UINT }, {"AR"  , PARTYPE_UINT},  {"AI"  , PARTYPE_UINT  },
     {"FR"  , PARTYPE_NONE },  {"BT"  , PARTYPE_UINT }, {"BC"  , PARTYPE_STRING},{"DP" , PARTYPE_UINT  },
-    {"AD"  , PARTYPE_UINT },  {"SC"  , PARTYPE_STRING }
+    {"AD"  , PARTYPE_UINT },  {"SC"  , PARTYPE_STRING }, {"UG", PARTYPE_NONE }
 };
 
 /**
@@ -495,6 +495,15 @@ void performCommand (uint8_t cmd, int16_t parNum, char * parString, int8_t perio
       case CMD_BC:
             Serial1.write(parString);
             Serial1.write('\n'); //terminate command
-            break;              
+            break;
+      case CMD_UG:
+            //we set this flag here, flushing & disabling serial port is done in loop()
+            addonUpgrade = 2;
+            Serial.println("Starting upgrade for BT addon!");
+            // Command for upgrade sent to ESP - triggering reset into factory reset mode
+            Serial1.println("$UG");
+            // delaying to ensure that UART command is sent and received
+            delay(500);
+            break;          
   }
 }

--- a/FabiWare/commands.h
+++ b/FabiWare/commands.h
@@ -86,6 +86,7 @@
           AT BT <uint>    set bluetooth mode, 1=USB only, 2=BT only, 3=both(default)
                           (e.g. AT BT 2 -> send HID commands only via BT if BT-daughter board is available)
           AT BC <string>  sends parameter to external UART (mostly ESP32 Bluetooth Addon)
+          AT UG           start addon upgrade, Serial ports are transparent until ("$FIN") is received.
 
    supported key identifiers for key press command (AT KP):
  
@@ -114,8 +115,8 @@ enum atCommands {
   CMD_ID, CMD_BM, CMD_CL, CMD_CR, CMD_CM, CMD_CD, CMD_HL, CMD_HR, CMD_HM, CMD_RL, CMD_RR, CMD_RM,
   CMD_TL, CMD_TR, CMD_TM, CMD_WU, CMD_WD, CMD_WS, CMD_MX, CMD_MY, CMD_KW, CMD_KP, CMD_KH, CMD_KT, 
   CMD_KR, CMD_RA, CMD_SA, CMD_LO, CMD_LA, CMD_LI, CMD_NE, CMD_DE, CMD_NC, CMD_SR, CMD_ER, CMD_TS, 
-  CMD_TP, CMD_MA, CMD_WA, CMD_TT, CMD_AP, CMD_AR, CMD_AI, CMD_FR, CMD_BT, CMD_BC, CMD_DP, CMD_AD, CMD_SC, 
-  NUM_COMMANDS
+  CMD_TP, CMD_MA, CMD_WA, CMD_TT, CMD_AP, CMD_AR, CMD_AI, CMD_FR, CMD_BT, CMD_BC, CMD_DP, CMD_AD, CMD_SC,
+  CMD_UG, NUM_COMMANDS
 };
 
 #define PARTYPE_NONE   0

--- a/FabiWare/fabi.h
+++ b/FabiWare/fabi.h
@@ -91,6 +91,7 @@ struct buttonDebouncerType {       // holds working data for button debouncing a
 
 extern uint8_t PCBversion;
 extern uint8_t actSlot;
+extern uint8_t addonUpgrade;
 extern uint8_t reportSlotParameters;
 extern uint8_t reportRawValues;
 extern struct settingsType settings;


### PR DESCRIPTION
This PR implements the `AT UG` command for FABI, where an attached ESP32 addon can be upgraded.
(see https://github.com/asterics/esp32_addon_bootloader)

In addition, the problem with garbage & empty data from Serial1 without an attached ESP32 addon is fixed, by
enabling the pullup resistor on the RX line.

@fussthalerAndreas @ChrisVeigl 
There shouldn't be any influence, but please have a short look.

The upgrade functionality can be tested ONLY if the bootloader from the above mentioned repo is flashed on the ESP32 addon.
If you want to upload the esp32_mouse_keyboard firmware, please use the update.py script.